### PR TITLE
Remove remove_prohibited_routes()

### DIFF
--- a/virtnet/context.py
+++ b/virtnet/context.py
@@ -32,8 +32,6 @@ class Manager(object):
     def simple_route(self) -> None:
         "Add routes between routers"
         for host in filter(lambda x: hasattr(x, 'find_routes'), self.registered):
-            host.remove_prohibited_routes()
-        for host in filter(lambda x: hasattr(x, 'find_routes'), self.registered):
             host.find_routes()
 
     def __enter__(self) -> 'Manager':


### PR DESCRIPTION
When specifying a route direction, we currently obey this direction even for routing decisions to locally reachable subnets, by removing automatically generated routing table entries. This might lead to unintuitive behaviour for complex networks and, as discussed offline, is unintended for our particular use case. 

This PR reduces the significance of the route direction to transit traffic. Alternatively, we could try to retain the functionality, which, however, would increase code complexity.