### PR TITLE
Fix module NetNS import path for pyroute2 0.6.9

### DIFF
--- a/virtnet/host.py
+++ b/virtnet/host.py
@@ -13,7 +13,7 @@ import pathlib
 import os
 import errno
 import shutil
-from pyroute2.netns.nslink import NetNS
+from pyroute2.nslink import NetNS
 from pyroute2.netns import setns
 import pyroute2.ipdb.main
 import ipaddress


### PR DESCRIPTION
`pyroute2.netns.nslink` does not exist in latest pyroute2 (0.6.9) but `pyroute2.nslink` does.

Alternatively the specific supported pyroute2 version could be specified in https://github.com/CN-TU/py-virtnet/blob/3e75298bc41ee942a09e7e9b1451f9dba4824af0/setup.py#L46 with https://stackoverflow.com/a/8161816/3586583